### PR TITLE
DB 疎通検証用タスクを実装

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,6 @@ services:
     volumes:
       - ./test_app/:/app
     working_dir: /app
-    command: robots
   web:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,17 @@ services:
       WRITER_DB_PASSWORD: password
     volumes:
       - ./test_app/:/app
+  task:
+    build:
+      context: .
+      dockerfile: ./docker/task/Dockerfile
+    environment:
+      FUEL_ENV: test
+      WRITER_DB_PASSWORD: password
+    volumes:
+      - ./test_app/:/app
+    working_dir: /app
+    command: robots
   web:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       context: .
       dockerfile: ./docker/app/Dockerfile
     environment:
+      FUEL_ENV: test
       WRITER_DB_PASSWORD: password
     volumes:
       - ./test_app/:/app

--- a/docker/app/Dockerfile
+++ b/docker/app/Dockerfile
@@ -5,7 +5,7 @@ ENV TZ Asia/Tokyo
 RUN apt-get update && \
 	apt-get install -y git unzip libzip-dev libicu-dev libonig-dev default-mysql-client && \
 	docker-php-ext-install intl pdo_mysql mysqli zip bcmath
-		
+
 COPY ./docker/app/php.ini /usr/local/etc/php/php.ini
 
 COPY --from=composer:2.0 /usr/bin/composer /usr/bin/composer

--- a/docker/task/Dockerfile
+++ b/docker/task/Dockerfile
@@ -1,0 +1,19 @@
+FROM php:8.1-fpm
+
+ENV TZ Asia/Tokyo
+
+RUN apt-get update && \
+	apt-get install -y git unzip libzip-dev libicu-dev libonig-dev default-mysql-client && \
+	docker-php-ext-install intl pdo_mysql mysqli zip bcmath
+
+COPY ./docker/app/php.ini /usr/local/etc/php/php.ini
+
+COPY --from=composer:2.0 /usr/bin/composer /usr/bin/composer
+
+COPY ./test_app /app
+
+WORKDIR /app
+
+RUN composer install
+
+ENTRYPOINT ["php", "oil", "refine"]

--- a/docker/task/php.ini
+++ b/docker/task/php.ini
@@ -1,0 +1,27 @@
+zend.exception_ignore_args = off
+expose_php = on
+max_execution_time = 30
+max_input_vars = 1000
+upload_max_filesize = 64M
+post_max_size = 128M
+memory_limit = 256M
+error_reporting = E_ALL
+display_errors = on
+display_startup_errors = on
+log_errors = on
+error_log = /var/log/php/php-error.log
+default_charset = UTF-8
+extension=mysqli
+mysqli.default_port=33060
+
+[Date]
+date.timezone = Asia/Tokyo
+
+[mysqlnd]
+mysqlnd.collect_memory_statistics = on
+
+[Assertion]
+zend.assertions = 1
+
+[mbstring]
+mbstring.language = Japanese

--- a/test_app/fuel/app/config/db.php
+++ b/test_app/fuel/app/config/db.php
@@ -7,7 +7,6 @@ return [
     'default' => [
         'type'           => 'mysqli',
         'connection'     => [
-            'username'       => 'admin',
             'password'       => getenv('WRITER_DB_PASSWORD'),
             'persistent'     => false,
             'compress'       => false,

--- a/test_app/fuel/app/config/development/db.php
+++ b/test_app/fuel/app/config/development/db.php
@@ -26,6 +26,7 @@
             'hostname'       => 'secure-connection-test.cluster-cptunb5lgmjv.ap-northeast-1.rds.amazonaws.com',
             'port'           => '3306',
             'database'       => 'db_secure_connection_test',
+            'username'       => 'admin',
         ],
     ],
 ];

--- a/test_app/fuel/app/config/production/db.php
+++ b/test_app/fuel/app/config/production/db.php
@@ -26,6 +26,7 @@ return array(
             'hostname'       => 'db',
             'port'           => '3306',
             'database'       => 'test',
+            'username'       => 'user'
         ],
 	),
 );

--- a/test_app/fuel/app/config/staging/db.php
+++ b/test_app/fuel/app/config/staging/db.php
@@ -26,6 +26,7 @@ return array(
             'hostname'       => 'db',
             'port'           => '3306',
             'database'       => 'test',
+            'username'       => 'user'
         ],
 	),
 );

--- a/test_app/fuel/app/config/test/db.php
+++ b/test_app/fuel/app/config/test/db.php
@@ -24,11 +24,11 @@
 
 return array(
 	'default' => array(
-        'type'           => 'mysqli',
+        'type'           => 'pdo',
         'connection'     => [
-            'hostname'       => 'db',
+            'dsn'            => 'mysql:host=db;dbname=test',
             'port'           => '3306',
-            'database'       => 'test',
+            'username'       => 'user'
         ],
 	),
 );

--- a/test_app/fuel/app/config/test/migrations.php
+++ b/test_app/fuel/app/config/test/migrations.php
@@ -1,0 +1,22 @@
+<?php
+return array(
+  'version' => 
+  array(
+    'app' => 
+    array(
+      'default' => 
+      array(
+        0 => '001_create_users',
+      ),
+    ),
+    'module' => 
+    array(
+    ),
+    'package' => 
+    array(
+    ),
+  ),
+  'folder' => 'migrations/',
+  'table' => 'migration',
+  'flush_cache' => false,
+);

--- a/test_app/fuel/app/tasks/example.php
+++ b/test_app/fuel/app/tasks/example.php
@@ -1,0 +1,11 @@
+<?php
+namespace Fuel\Tasks;
+
+class Example
+{
+
+	public function run($message = 'Hello!')
+	{
+		echo $message;
+	}
+}

--- a/test_app/fuel/app/tasks/example.php
+++ b/test_app/fuel/app/tasks/example.php
@@ -4,8 +4,9 @@ namespace Fuel\Tasks;
 class Example
 {
 
-	public function run($message = 'Hello!')
+	public function run()
 	{
-		echo $message;
+        $users = \Model_User::find('all');
+        print_r($users);
 	}
 }


### PR DESCRIPTION
タイトル通りです。`app` コンテナとは別に `task` コンテナを実装し、以下のようなコマンドでローカルでの実行をできるようにしました。

```sh
docker compose run task example
```

エントリポイント側に `php oil refine` があるため、タスク名の記載だけで動作します。